### PR TITLE
Use lastReadMessage for first lastKnownMessageId

### DIFF
--- a/room/room.go
+++ b/room/room.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"io/ioutil"
+	"strconv"
 	"time"
 
 	"github.com/monaco-io/request"
@@ -98,16 +99,16 @@ func (t *TalkRoom) ReceiveMessages(ctx context.Context) (chan ocs.TalkRoomMessag
 		"includeLastKnown": "0",
 	}
 	lastKnown := ""
-	client := t.User.RequestClient(request.Client{
-		URL:     url,
-		Params:  requestParam,
-		Timeout: time.Second * 60,
-	})
-	res, err := client.Resp()
+	res, err := t.User.GetRooms()
 	if err != nil {
 		return nil, err
 	}
-	lastKnown = res.Header.Get("X-Chat-Last-Given")
+	for _, r := range *res {
+		if r.Token == t.Token {
+			lastKnown = strconv.Itoa(r.LastReadMessage)
+			break
+		}
+	}
 	go func() {
 		for {
 			if ctx.Err() != nil {


### PR DESCRIPTION
This solves a problem where matterbridge spams a lot of old nctalk messages into bridged rooms on every restart.

So instead of using 0 as the first lastKnownMessageId, we used lastReadMessage from the room endpoint.
This is also what the nextcloud talk web client does, see:
https://github.com/nextcloud/spreed/blob/cabb7b6b4782a63b0daa9b54a3a283cf2386e755/src/components/MessagesList/MessagesList.vue#L333-L336
