### PR TITLE
Trim slash from end of NextcloudURL

### DIFF
--- a/gonctalk.go
+++ b/gonctalk.go
@@ -15,6 +15,8 @@
 package talk
 
 import (
+	"strings"
+
 	"gomod.garykim.dev/nc-talk/room"
 	"gomod.garykim.dev/nc-talk/user"
 )
@@ -25,7 +27,7 @@ import (
 // Deprecated: Use user.NewTalkUser instead for more options and error checks
 func NewUser(url string, username string, password string) *user.TalkUser {
 	return &user.TalkUser{
-		NextcloudURL: url,
+		NextcloudURL: strings.TrimSuffix(url, "/"),
 		User:         username,
 		Pass:         password,
 	}

--- a/user/user.go
+++ b/user/user.go
@@ -118,7 +118,7 @@ type RoomInfo struct {
 // The url should be the full URL of the Nextcloud instance (e.g. https://cloud.mydomain.me)
 func NewUser(url string, username string, password string, config *TalkUserConfig) (*TalkUser, error) {
 	return &TalkUser{
-		NextcloudURL: url,
+		NextcloudURL: strings.TrimSuffix(url, "/"),
 		User:         username,
 		Pass:         password,
 		Config:       config,
@@ -143,7 +143,11 @@ func (t *TalkUser) RequestClient(client request.Client) *request.Client {
 
 	// Set Nextcloud URL if there is no host
 	if !strings.HasPrefix(client.URL, t.NextcloudURL) {
-		client.URL = t.NextcloudURL + "/" + client.URL
+		if strings.HasPrefix(client.URL, "/") {
+			client.URL = t.NextcloudURL + client.URL
+		} else {
+			client.URL = t.NextcloudURL + "/" + client.URL
+		}
 	}
 
 	// Set TLS Config


### PR DESCRIPTION
A slash at the end of NextcloudURL can cause
double slashes in requests which can be a problem.

ref: https://github.com/nextcloud/talk_matterbridge/issues/15

Signed-off-by: Gary Kim <gary@garykim.dev>